### PR TITLE
Update CH-Ketten

### DIFF
--- a/ketten.csv
+++ b/ketten.csv
@@ -35,7 +35,9 @@ CH,bakery,Hausammann Zopfbeck,,open,,,http://www.zopfbeck.ch/,http://www.zopfbec
 CH,bakery,Hug,,open,,,https://www.baeckerei-hug.ch,https://www.baeckerei-hug.ch/filialen/standorte/
 CH,bakery,Kleiner,,open,,,https://kleiner-baeckerei.ch,https://kleiner-baeckerei.ch/standorte/
 CH,bakery,Steiner Beck,,partial,,,https://www.steiner-beck.ch/news-coronavirus/,https://www.steiner-beck.ch/filialen/
+CH,bakery,Steiner Flughafebeck,,open_adapted,,,https://www.flughafebeck.ch/standorte/,
 CH,bakery,Voland,,open,,,https://www.baumerfladen.ch/,https://www.baumerfladen.ch/filialen
+CH,bakery,Walter Buchmann AG,,open,,,https://www.buchmannbeck.ch/standorte/,
 CH,bakery,Wüst,,open,,,https://baeckereiwuest.ch/,https://baeckereiwuest.ch/filialen
 CH,bank,Aargauische Kantonalbank,Q301269,open,,,https://www.akb.ch/coronavirus,https://www.akb.ch
 CH,bank,Appenzeller Kantonalbank,Q620963,partial,,,https://www.appkb.ch/private/NEWSID-926,https://www.appkb.ch
@@ -61,18 +63,25 @@ CH,bank,UBS,Q193199,partial,,,https://www.ubs.com/ch/de/help/covid-info.html,
 CH,bank,Urner Kantonalbank,Q17051583,open,,,https://www.ukb.ch/unsere-bank/portrait/aktueller-bankbetrieb/,https://www.ukb.ch
 CH,bank,Walliser Kantonalbank,Q2543025,open,,,https://www.bcvs.ch/,https://www.bcvs.ch/
 CH,bank,Zuger Kantonalbank,Q228365,open,,,https://www.zugerkb.ch/die-zugerkb/zuger-kantonalbank/coronavirus,https://www.zugerkb.ch
-CH,bank,Zürcher Kantonalbank,Q248476,open,,,https://www.zkb.ch/de/gs/lp/pandemie-kundeninformation.html,https://www.zkb.ch
+CH,bank,Zürcher Kantonalbank,Q248476,partial,,,https://www.zkb.ch/de/gs/lp/pandemie-kundeninformation.html,https://www.zkb.ch
+CH,books,Ex Libris,,closed,,,,
+CH,books,Orell Füssli,,closed,,,,
+CH,books,Weltbild,,closed,,,,
+CH,chemist,Achillea Apotheke,,open,,,,
 CH,chemist,Amavita,,open,,,https://www.amavita.ch/de/info-covid19,https://www.amavita.ch/de/storepickup
+CH,chemist,Coop Vitality,,open,,,,
 CH,chemist,Dropa,Q1260273,open,,,https://dropa.ch/ratgeber/alle-dropa-drogerien-und-apotheken-sind-geoeffnet,https://dropa.ch
+CH,chemist,Medbase Apotheken,,open,,,,
 CH,chemist,Rotpunkt Apotheke,,open,,,,
 CH,chemist,TopPharm,,open,,,,https://www.toppharm.ch/hauslieferdienst
-CH,doityourself,Bauhaus,Q672043,partial,,,https://www.bauhaus.ch/de/content/aktuelles/aktuelle-situation.html,https://www.bauhaus.ch
-CH,doityourself,Coop Bau + Hobby,Q432564,partial,,,,https://www.bauundhobby.ch/
-CH,doityourself,Do it & Garden,Q680727,partial,,,https://www.doitgarden.ch/de/cp/aktuell,https://www.doitgarden.ch
-CH,doityourself,Hornbach,Q685926,partial,,,https://www.hornbach.ch/aktuelles/aktuelle-informationen/,https://www.hornbach.ch/
-CH,doityourself,Jumbo,,partial,,,https://www.jumbo.ch/de/coronavirus-info,https://www.jumbo.ch/de
+CH,chemist,Topwell Apotheken AG,,open,,,,
+CH,doityourself,Bauhaus,Q672043,closed,,,https://www.bauhaus.ch/de/content/aktuelles/aktuelle-situation.html,https://www.bauhaus.ch
+CH,doityourself,Coop Bau+Hobby,Q432564,partial,,,,https://www.bauundhobby.ch/
+CH,doityourself,Do it + Garden,Q680727,closed,,,https://www.doitgarden.ch/de/cp/aktuell,https://www.doitgarden.ch
+CH,doityourself,Hornbach,Q685926,closed,,,https://www.hornbach.ch/aktuelles/aktuelle-informationen/,https://www.hornbach.ch/
+CH,doityourself,Jumbo,,closed,,,https://www.jumbo.ch/de/coronavirus-info,https://www.jumbo.ch/de
 CH,doityourself,Landi,Q1803010,partial,,,https://www.landi.ch/laden/service/Haeufig-gestellte-Fragen-FAQ,https://www.landi.ch/places/de
-CH,doityourself,OBI,Q300518,partial,,,,https://www.obi.ch/
+CH,doityourself,OBI,Q300518,closed,,,,https://www.obi.ch/
 CH,electronics,Inter Discount,,closed,,,https://www.interdiscount.ch/de,
 CH,electronics,melectronics,,closed,,,https://www.melectronics.ch/de,
 CH,fastfood,Burger King,Q177054,partial,,,https://de.burger-king.ch/promo/13318,https://de.burger-king.ch/kingfinder
@@ -81,12 +90,14 @@ CH,fuel,Agip,Q377915,open,,,,
 CH,fuel,Agrola,Q397351,open,,,,https://www.agrola.ch/de/mobilitaet/tankstellen/standorte/tankstellen.html
 CH,fuel,Avia,,open,,,https://avia.ch/,https://avia.ch/tankstellen/tankstellenfinder/
 CH,fuel,BP,Q152057,open,,,https://www.bp.com/de_ch/switzerland/home/produkte-und-services/bp-in-ihrer-naehe.html,
+CH,fuel,Coop,Q1129777,open,,,,
 CH,fuel,Eni,Q565594,open,,,,
 CH,fuel,Esso,Q867662,open,,,,
 CH,fuel,Migrol,Q1747771,open,,,https://www.migrol.ch/de/mobilit%C3%A4t/,https://www.migrol.ch/de/mobilit%C3%A4t/
 CH,fuel,Socar,Q1622293,open,,,https://www.socarenergy.ch/,https://www.socarenergy.ch/tankstellen/tankstellen-finder/
 CH,fuel,Shell,Q154950,open,,,,
 CH,fuel,Tamoil,Q706793,open,,,,https://www.tamoil.ch/de/eine-tankstelle-finden
+CH,kiosk,Avec,,partial,,,,,
 CH,kiosk,k kiosk,Q60381703,partial,,,https://www.kkiosk.ch/de/allover/standortsuche/,https://www.kkiosk.ch/de/allover/standortsuche/
 CH,kiosk,Valora,Q60381703,partial,,,https://www.kkiosk.ch/de/allover/standortsuche/,https://www.kkiosk.ch/de/allover/standortsuche/
 CH,optician,Fielmann,Q457822,partial,,nur Notfälle,https://www.fielmann.ch,https://www.fielmann.ch/de/niederlassungen/
@@ -98,21 +109,21 @@ CH,post,Die Post,Q614803,open,,Nur postalische Produkte und Dienstleistungen,htt
 CH,post,Post,Q614803,open,,Nur postalische Produkte und Dienstleistungen,https://www.post.ch/de/pages/corona/anpassungen-im-angebot,https://www.post.ch/de/pages/corona/anpassungen-im-angebot
 CH,post,Die Schweizerische Post AG,Q614803,open,,Nur postalische Produkte und Dienstleistungen,https://www.post.ch/de/pages/corona/anpassungen-im-angebot,https://www.post.ch/de/pages/corona/anpassungen-im-angebot
 CH,supermarket,Aldi,Q125054,open,,,,https://www.aldi-suisse.ch/filialen/de-CH/Start
-CH,supermarket,Coop Pronto,Q1129777,open,,,,https://www.coop-pronto.ch/de/standorte-oeffnungszeiten/
-CH,supermarket,Coop Genossenschaft,Q432564,open,,,,https://www.coop.ch/de/unternehmen/standorte-und-oeffnungszeiten.html
+CH,supermarket,Alnatura,,open,,,,https://filialen.migros.ch/de
 CH,supermarket,Coop,Q432564,open,,,,https://www.coop.ch/de/unternehmen/standorte-und-oeffnungszeiten.html
+CH,supermarket,Coop Pronto,Q1129777,open,,,,https://www.coop-pronto.ch/de/standorte-oeffnungszeiten/
 CH,supermarket,Denner,Q379911,open,,,,https://www.denner.ch/de/filialen/
 CH,supermarket,LIDL,Q151954,open,,,,https://www.lidl.ch/unternehmen/filialen-oeffnungszeiten/filialfinder
 CH,supermarket,Manor,,partial,,,https://www.manor.ch/de/u/manor-info-covid19,https://www.manor.ch/de/store-finder
 CH,supermarket,Migros,Q680727,open,,,,https://filialen.migros.ch/de
-CH,supermarket,Genossenschaft Migros Zürich,Q680727,open,,,,https://filialen.migros.ch/de
 CH,supermarket,Migrolino,Q56745088,open,,,https://www.migrolino.ch/de/,https://www.migrolino.ch/de/migrolino-standorte/
-CH,supermarket,Migros,Q680727,open,,,,https://filialen.migros.ch/de
 CH,supermarket,SPAR,Q610492,open,,,,https://www.spar.ch/spar-maerkte/#?s=1
+CH,supermarket,VOI,,open,,,,https://filialen.migros.ch/de
 CH,supermarket,Volg,Q2530746,open,,,,https://www.volg.ch/standorte-oeffnungszeiten/
+CH,telecommunication,Mobilezone,,partial,,,,
 CH,telecommunication,Salt,Q17325543,open,,,,
 CH,telecommunication,Sunrise,Q672648,open,,,,
-CH,telecommunication,Swisscom,Q644324,open,,,,
+CH,telecommunication,Swisscom,Q644324,partial,Mo-Sa 10:00-15:00,,https://www.swisscom.ch/de/privatkunden/hilfe/shops.html,
 DE,bakery,Back-Factory,Q21200483,closed,,,https://www.back-factory.de/wir-sind-bald-wieder-da/wir-sind-bald-wieder-da.html,
 DE,bakery,BackWerk,Q798298,partial,,,https://www.back-werk.de/,https://www.back-werk.de/standorte/
 DE,bakery,Ditsch,Q911573,partial,,,,https://www.ditsch.de/de/shops/

--- a/ketten.csv
+++ b/ketten.csv
@@ -97,7 +97,7 @@ CH,fuel,Migrol,Q1747771,open,,,https://www.migrol.ch/de/mobilit%C3%A4t/,https://
 CH,fuel,Socar,Q1622293,open,,,https://www.socarenergy.ch/,https://www.socarenergy.ch/tankstellen/tankstellen-finder/
 CH,fuel,Shell,Q154950,open,,,,
 CH,fuel,Tamoil,Q706793,open,,,,https://www.tamoil.ch/de/eine-tankstelle-finden
-CH,kiosk,Avec,,partial,,,,,
+CH,kiosk,Avec,,partial,,,,
 CH,kiosk,k kiosk,Q60381703,partial,,,https://www.kkiosk.ch/de/allover/standortsuche/,https://www.kkiosk.ch/de/allover/standortsuche/
 CH,kiosk,Valora,Q60381703,partial,,,https://www.kkiosk.ch/de/allover/standortsuche/,https://www.kkiosk.ch/de/allover/standortsuche/
 CH,optician,Fielmann,Q457822,partial,,nur Notfälle,https://www.fielmann.ch,https://www.fielmann.ch/de/niederlassungen/


### PR DESCRIPTION
Hinzugefügt:
+ bakery Steiner Flughafebeck, Walter Buchmann
+ supermarket Alnatura (Migros), VOI (Migros)
+ telco Mobilezone
+ fuel Coop
+ books OF, Weltbild, Ex Libris
+ chemist Achillea (Dropa), Topwell/Medbase (Migros), Coop Vitality

Entferntes Duplikat:
- supermarket Migros (DUPLIKAT)

Diverse Anpassungen:
* bank ZKB (nur 15 Filialen haben geöffnet > partial)
* doityourself Bauhaus, Jumbo, Hornbach, Do it + Garden (Migros), Obi (Migros) sind fix geschlossen und bieten keine Abholung an den Standorten an (> closed); Landi und Coop B+H sind mit partial (Abholung an den Filialstandorten) korrekt
* telco Swisscom (nicht alle Filialen haben geöffnet > partial; offene Filialen fix Mo-Sa 10:00-15:00)

Folgende beiden Einträge hätten gar nicht erst aufgenommen werden dürfen:
'Coop Genossenschaft' und 'Genossenschaft Migros Zürich' (bzw. jede Genossenschaft Migros XY). Das sind die juristischen Personen hinter allen Konzernmarken, die nicht in eigenständigen Tochterunternehmen organisiert sind, also die meisten Fachmärkte, Parfümerien, Juweliere, Fitnessparks, Golfparks, Restaurants etc. die allesamt geschlossen sind. Entfernt da sie die Quelle diverser false-positives sind.